### PR TITLE
Add PDF extraction script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# New Codex Project
+# WirelessOffice Data Extraction
+
+This repository contains a utility script for extracting text and metadata from PDF files and compiling the results into a single JSON file.
+
+## Usage
+
+1. Install dependencies:
+
+   ```bash
+   pip install pdfminer.six PyPDF2
+   ```
+
+2. Run the script (adjust the directory path as necessary):
+
+   ```bash
+   python extract_pdf_data.py -d "E:\\OneDrive - Above Wireless LLC\\Work\\GTC\\Purchase Repairs - Climbed" -o output.json
+   ```
+
+The script will recursively search the given directory for PDF files, extract their text and metadata, and save the combined data into `output.json`.

--- a/extract_pdf_data.py
+++ b/extract_pdf_data.py
@@ -1,0 +1,69 @@
+import os
+import json
+import argparse
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pdfminer.high_level import extract_text
+from PyPDF2 import PdfReader
+
+def extract_pdf_data(pdf_path: str) -> dict:
+    """Extract text and metadata from a single PDF file."""
+    data = {"file": os.path.basename(pdf_path)}
+
+    try:
+        data["text"] = extract_text(pdf_path)
+    except Exception as exc:  # pragma: no cover - extraction failures
+        data["text_error"] = str(exc)
+
+    try:
+        reader = PdfReader(pdf_path)
+        if reader.metadata:
+            data["metadata"] = {k: str(v) for k, v in reader.metadata.items()}
+    except Exception as exc:  # pragma: no cover
+        data["metadata_error"] = str(exc)
+
+    return data
+
+def gather_pdfs(root_dir: str) -> list:
+    """Recursively find PDF files in *root_dir*."""
+    return [
+        os.path.join(dirpath, filename)
+        for dirpath, _, filenames in os.walk(root_dir)
+        for filename in filenames
+        if filename.lower().endswith(".pdf")
+    ]
+
+def main(directory: str, output: str) -> None:
+    pdf_paths = gather_pdfs(directory)
+    results = []
+
+    with ThreadPoolExecutor() as executor:
+        future_map = {
+            executor.submit(extract_pdf_data, path): path for path in pdf_paths
+        }
+        for future in as_completed(future_map):
+            try:
+                results.append(future.result())
+            except Exception as exc:  # pragma: no cover
+                results.append({"file": os.path.basename(future_map[future]), "error": str(exc)})
+
+    with open(output, "w", encoding="utf-8") as fh:
+        json.dump(results, fh, ensure_ascii=False, indent=2)
+
+def cli() -> None:
+    parser = argparse.ArgumentParser(
+        description="Extract text and metadata from all PDF files within a directory."
+    )
+    parser.add_argument(
+        "-d",
+        "--directory",
+        default=r"E:\\OneDrive - Above Wireless LLC\\Work\\GTC\\Purchase Repairs - Climbed",
+        help="Directory containing PDF files",
+    )
+    parser.add_argument(
+        "-o", "--output", default="pdf_data.json", help="Output JSON file"
+    )
+    args = parser.parse_args()
+    main(args.directory, args.output)
+
+if __name__ == "__main__":  # pragma: no cover
+    cli()


### PR DESCRIPTION
## Summary
- add `extract_pdf_data.py` to gather text and metadata from PDFs into a JSON file
- document usage and dependencies in README

## Testing
- `python -m py_compile extract_pdf_data.py`
- `python extract_pdf_data.py -d /tmp -o test.json`

------
https://chatgpt.com/codex/tasks/task_b_68b754af3d6483228579b244892dd1b5