### PR TITLE
Add enterprise-ready state scaffolding and ViewModel-backed UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -1,22 +1,40 @@
-# WirelessOffice
+# WirelessOffice Web App
 
-A native Android starter for the Dillon Tower-inspired BLE companion app.
+WirelessOffice is now a web app scaffold that mirrors the same core flows we started on mobile:
+
+- Onboarding and permission readiness
+- BLE device list simulation
+- Device detail view
+- Diagnostics log workflow
 
 ## Requirements
 
-- Android Studio Hedgehog or newer
-- JDK 17
+- Node.js 20+
+- npm 10+
 
-## Run
+## Run locally
 
-1. Open the project in Android Studio.
-2. Sync Gradle and run the `app` configuration on a device or emulator.
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the dev server:
+   ```bash
+   npm run dev
+   ```
+3. Open the local URL shown in terminal (typically `http://localhost:5173`).
 
-## Architecture notes
+## Production build
 
-- Compose UI with a single-activity navigation graph.
-- ViewModels expose immutable UI state backed by repository interfaces.
-- Repository implementations are currently in-memory fakes to keep the app runnable while BLE and permissions are wired.
+```bash
+npm run build
+npm run preview
+```
+
+## Notes
+
+- Current BLE/permissions are mocked using in-memory fake APIs in `src/data/mockApi.ts`.
+- The existing Android scaffold remains in `app/` for reference during migration.
 
 ## Reports
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# New Codex Project
+# WirelessOffice
+
+A native Android starter for the Dillon Tower-inspired BLE companion app.
+
+## Requirements
+
+- Android Studio Hedgehog or newer
+- JDK 17
+
+## Run
+
+1. Open the project in Android Studio.
+2. Sync Gradle and run the `app` configuration on a device or emulator.
+
+## Architecture notes
+
+- Compose UI with a single-activity navigation graph.
+- ViewModels expose immutable UI state backed by repository interfaces.
+- Repository implementations are currently in-memory fakes to keep the app runnable while BLE and permissions are wired.
+
+## Reports
+
+- [Dillon Tower APK deconstruction](reports/dillon-tower-apk-deconstruction.md)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,81 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.wirelessoffice"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.wirelessoffice"
+        minSdk = 25
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0.0"
+
+        vectorDrawables {
+            useSupportLibrary = true
+        }
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.8"
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+        isCoreLibraryDesugaringEnabled = true
+    }
+
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+}
+
+dependencies {
+    val composeBom = platform("androidx.compose:compose-bom:2024.02.01")
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0")
+    implementation("androidx.activity:activity-compose:1.8.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.navigation:navigation-compose:2.7.6")
+
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Add project specific ProGuard rules here.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,36 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
+    <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
+    <uses-feature android:name="android.hardware.location" android:required="false" />
+    <uses-feature android:name="android.hardware.location.gps" android:required="false" />
+    <uses-feature android:name="android.hardware.location.network" android:required="false" />
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.WirelessOffice">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/wirelessoffice/MainActivity.kt
+++ b/app/src/main/java/com/wirelessoffice/MainActivity.kt
@@ -1,0 +1,31 @@
+package com.wirelessoffice
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.compose.rememberNavController
+import com.wirelessoffice.ui.WirelessOfficeApp
+import com.wirelessoffice.ui.theme.WirelessOfficeTheme
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            WirelessOfficeTheme {
+                Surface(modifier = Modifier.fillMaxSize()) {
+                    WirelessOfficeRoot()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WirelessOfficeRoot() {
+    val navController = rememberNavController()
+    WirelessOfficeApp(navController = navController)
+}

--- a/app/src/main/java/com/wirelessoffice/core/ServiceLocator.kt
+++ b/app/src/main/java/com/wirelessoffice/core/ServiceLocator.kt
@@ -1,0 +1,14 @@
+package com.wirelessoffice.core
+
+import com.wirelessoffice.data.DiagnosticsRepository
+import com.wirelessoffice.data.FakeDiagnosticsRepository
+import com.wirelessoffice.data.FakePermissionsRepository
+import com.wirelessoffice.data.FakeScannerRepository
+import com.wirelessoffice.data.PermissionsRepository
+import com.wirelessoffice.data.ScannerRepository
+
+object ServiceLocator {
+    val scannerRepository: ScannerRepository by lazy { FakeScannerRepository() }
+    val permissionsRepository: PermissionsRepository by lazy { FakePermissionsRepository() }
+    val diagnosticsRepository: DiagnosticsRepository by lazy { FakeDiagnosticsRepository() }
+}

--- a/app/src/main/java/com/wirelessoffice/data/DiagnosticsRepository.kt
+++ b/app/src/main/java/com/wirelessoffice/data/DiagnosticsRepository.kt
@@ -1,0 +1,10 @@
+package com.wirelessoffice.data
+
+import com.wirelessoffice.model.DiagnosticsEntry
+import kotlinx.coroutines.flow.StateFlow
+
+interface DiagnosticsRepository {
+    val entries: StateFlow<List<DiagnosticsEntry>>
+    suspend fun log(message: String)
+    suspend fun clear()
+}

--- a/app/src/main/java/com/wirelessoffice/data/FakeDiagnosticsRepository.kt
+++ b/app/src/main/java/com/wirelessoffice/data/FakeDiagnosticsRepository.kt
@@ -1,0 +1,40 @@
+package com.wirelessoffice.data
+
+import com.wirelessoffice.model.DiagnosticsEntry
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.time.Instant
+import java.util.UUID
+
+class FakeDiagnosticsRepository : DiagnosticsRepository {
+    private val _entries = MutableStateFlow(
+        listOf(
+            DiagnosticsEntry(
+                id = UUID.randomUUID().toString(),
+                message = "App launched",
+                timestamp = Instant.now()
+            ),
+            DiagnosticsEntry(
+                id = UUID.randomUUID().toString(),
+                message = "BLE adapter ready",
+                timestamp = Instant.now()
+            )
+        )
+    )
+
+    override val entries: StateFlow<List<DiagnosticsEntry>> = _entries.asStateFlow()
+
+    override suspend fun log(message: String) {
+        val newEntry = DiagnosticsEntry(
+            id = UUID.randomUUID().toString(),
+            message = message,
+            timestamp = Instant.now()
+        )
+        _entries.value = _entries.value + newEntry
+    }
+
+    override suspend fun clear() {
+        _entries.value = emptyList()
+    }
+}

--- a/app/src/main/java/com/wirelessoffice/data/FakePermissionsRepository.kt
+++ b/app/src/main/java/com/wirelessoffice/data/FakePermissionsRepository.kt
@@ -1,0 +1,24 @@
+package com.wirelessoffice.data
+
+import com.wirelessoffice.model.PermissionState
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class FakePermissionsRepository : PermissionsRepository {
+    private val _permissions = MutableStateFlow(
+        PermissionState(
+            bluetooth = true,
+            location = false,
+            camera = true
+        )
+    )
+
+    override val permissions: StateFlow<PermissionState> = _permissions.asStateFlow()
+
+    override suspend fun refresh() {
+        delay(250)
+        _permissions.value = _permissions.value.copy(location = true)
+    }
+}

--- a/app/src/main/java/com/wirelessoffice/data/FakeScannerRepository.kt
+++ b/app/src/main/java/com/wirelessoffice/data/FakeScannerRepository.kt
@@ -1,0 +1,53 @@
+package com.wirelessoffice.data
+
+import com.wirelessoffice.model.BleDevice
+import com.wirelessoffice.model.ConnectionStatus
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.util.UUID
+
+class FakeScannerRepository : ScannerRepository {
+    private val _devices = MutableStateFlow(sampleDevices())
+    private val _isScanning = MutableStateFlow(false)
+
+    override val devices: StateFlow<List<BleDevice>> = _devices.asStateFlow()
+    override val isScanning: StateFlow<Boolean> = _isScanning.asStateFlow()
+
+    override suspend fun startScan() {
+        _isScanning.value = true
+        delay(600)
+        _devices.value = sampleDevices().shuffled()
+    }
+
+    override suspend fun stopScan() {
+        _isScanning.value = false
+    }
+
+    private fun sampleDevices(): List<BleDevice> {
+        return listOf(
+            BleDevice(
+                id = UUID.randomUUID().toString(),
+                name = "Dillon Tower A1",
+                address = "C8:2B:96:AA:01:11",
+                rssi = -62,
+                status = ConnectionStatus.Available
+            ),
+            BleDevice(
+                id = UUID.randomUUID().toString(),
+                name = "Dillon Tower B3",
+                address = "C8:2B:96:AA:02:FF",
+                rssi = -70,
+                status = ConnectionStatus.Connected
+            ),
+            BleDevice(
+                id = UUID.randomUUID().toString(),
+                name = "Dillon Tower C7",
+                address = "C8:2B:96:AA:03:8C",
+                rssi = -81,
+                status = ConnectionStatus.Available
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/wirelessoffice/data/PermissionsRepository.kt
+++ b/app/src/main/java/com/wirelessoffice/data/PermissionsRepository.kt
@@ -1,0 +1,9 @@
+package com.wirelessoffice.data
+
+import com.wirelessoffice.model.PermissionState
+import kotlinx.coroutines.flow.StateFlow
+
+interface PermissionsRepository {
+    val permissions: StateFlow<PermissionState>
+    suspend fun refresh()
+}

--- a/app/src/main/java/com/wirelessoffice/data/ScannerRepository.kt
+++ b/app/src/main/java/com/wirelessoffice/data/ScannerRepository.kt
@@ -1,0 +1,11 @@
+package com.wirelessoffice.data
+
+import com.wirelessoffice.model.BleDevice
+import kotlinx.coroutines.flow.StateFlow
+
+interface ScannerRepository {
+    val devices: StateFlow<List<BleDevice>>
+    val isScanning: StateFlow<Boolean>
+    suspend fun startScan()
+    suspend fun stopScan()
+}

--- a/app/src/main/java/com/wirelessoffice/model/BleDevice.kt
+++ b/app/src/main/java/com/wirelessoffice/model/BleDevice.kt
@@ -1,0 +1,15 @@
+package com.wirelessoffice.model
+
+data class BleDevice(
+    val id: String,
+    val name: String,
+    val address: String,
+    val rssi: Int,
+    val status: ConnectionStatus
+)
+
+enum class ConnectionStatus {
+    Available,
+    Connecting,
+    Connected
+}

--- a/app/src/main/java/com/wirelessoffice/model/DiagnosticsEntry.kt
+++ b/app/src/main/java/com/wirelessoffice/model/DiagnosticsEntry.kt
@@ -1,0 +1,9 @@
+package com.wirelessoffice.model
+
+import java.time.Instant
+
+data class DiagnosticsEntry(
+    val id: String,
+    val message: String,
+    val timestamp: Instant
+)

--- a/app/src/main/java/com/wirelessoffice/model/PermissionState.kt
+++ b/app/src/main/java/com/wirelessoffice/model/PermissionState.kt
@@ -1,0 +1,7 @@
+package com.wirelessoffice.model
+
+data class PermissionState(
+    val bluetooth: Boolean,
+    val location: Boolean,
+    val camera: Boolean
+)

--- a/app/src/main/java/com/wirelessoffice/ui/WirelessOfficeApp.kt
+++ b/app/src/main/java/com/wirelessoffice/ui/WirelessOfficeApp.kt
@@ -1,0 +1,54 @@
+package com.wirelessoffice.ui
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import com.wirelessoffice.ui.screens.DiagnosticsScreen
+import com.wirelessoffice.ui.screens.DeviceDetailScreen
+import com.wirelessoffice.ui.screens.DeviceListScreen
+import com.wirelessoffice.ui.screens.OnboardingScreen
+
+sealed class AppRoute(val route: String) {
+    data object Onboarding : AppRoute("onboarding")
+    data object DeviceList : AppRoute("devices")
+    data object DeviceDetail : AppRoute("device_detail")
+    data object Diagnostics : AppRoute("diagnostics")
+}
+
+@Composable
+fun WirelessOfficeApp(navController: NavHostController, modifier: Modifier = Modifier) {
+    Scaffold(containerColor = MaterialTheme.colorScheme.background) { padding ->
+        NavHost(
+            navController = navController,
+            startDestination = AppRoute.Onboarding.route,
+            modifier = modifier.padding(padding)
+        ) {
+            composable(AppRoute.Onboarding.route) {
+                OnboardingScreen(
+                    onContinue = { navController.navigate(AppRoute.DeviceList.route) }
+                )
+            }
+            composable(AppRoute.DeviceList.route) {
+                DeviceListScreen(
+                    onDeviceSelected = { navController.navigate(AppRoute.DeviceDetail.route) },
+                    onDiagnostics = { navController.navigate(AppRoute.Diagnostics.route) }
+                )
+            }
+            composable(AppRoute.DeviceDetail.route) {
+                DeviceDetailScreen(
+                    onBack = { navController.popBackStack() }
+                )
+            }
+            composable(AppRoute.Diagnostics.route) {
+                DiagnosticsScreen(
+                    onBack = { navController.popBackStack() }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/wirelessoffice/ui/screens/DeviceDetailScreen.kt
+++ b/app/src/main/java/com/wirelessoffice/ui/screens/DeviceDetailScreen.kt
@@ -1,0 +1,44 @@
+package com.wirelessoffice.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun DeviceDetailScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(text = "Device detail", style = MaterialTheme.typography.headlineSmall)
+        Text(
+            text = "Service discovery and characteristic read/write will appear here once BLE is wired up.",
+            style = MaterialTheme.typography.bodyMedium
+        )
+        Card {
+            Column(
+                modifier = Modifier.padding(PaddingValues(16.dp)),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(text = "Connection state", style = MaterialTheme.typography.titleMedium)
+                Text(text = "Status: Connected (mock)")
+                Text(text = "Battery: 82% (mock)")
+                Text(text = "Firmware: 1.1.111")
+            }
+        }
+        Button(onClick = onBack) {
+            Text(text = "Back to devices")
+        }
+    }
+}

--- a/app/src/main/java/com/wirelessoffice/ui/screens/DeviceListScreen.kt
+++ b/app/src/main/java/com/wirelessoffice/ui/screens/DeviceListScreen.kt
@@ -1,0 +1,92 @@
+package com.wirelessoffice.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.wirelessoffice.model.ConnectionStatus
+import com.wirelessoffice.ui.viewmodel.DeviceListViewModel
+import com.wirelessoffice.ui.viewmodel.DeviceListViewModelFactory
+
+@Composable
+fun DeviceListScreen(
+    onDeviceSelected: () -> Unit,
+    onDiagnostics: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val viewModel: DeviceListViewModel = viewModel(factory = DeviceListViewModelFactory())
+    val uiState by viewModel.uiState.collectAsState()
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Row(horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(text = "Nearby devices", style = MaterialTheme.typography.headlineSmall)
+                Text(
+                    text = "Tap a device to connect and inspect services.",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+            Spacer(modifier = Modifier.size(12.dp))
+            AssistChip(
+                onClick = {},
+                label = { Text(text = if (uiState.isScanning) "Scanning" else "Idle") }
+            )
+        }
+
+        LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            items(uiState.devices) { device ->
+                Card(onClick = onDeviceSelected) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(text = device.name, style = MaterialTheme.typography.titleMedium)
+                        Text(text = "Address: ${device.address}")
+                        Text(text = "RSSI: ${device.rssi} dBm")
+                        Text(text = "Status: ${statusLabel(device.status)}")
+                    }
+                }
+            }
+        }
+
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            Button(onClick = onDiagnostics) {
+                Text(text = "Diagnostics")
+            }
+            if (uiState.isScanning) {
+                Button(onClick = viewModel::stopScan) {
+                    Text(text = "Stop scan")
+                }
+            } else {
+                Button(onClick = viewModel::startScan) {
+                    Text(text = "Start scan")
+                }
+            }
+        }
+    }
+}
+
+private fun statusLabel(status: ConnectionStatus): String = when (status) {
+    ConnectionStatus.Available -> "Available"
+    ConnectionStatus.Connecting -> "Connecting"
+    ConnectionStatus.Connected -> "Connected"
+}

--- a/app/src/main/java/com/wirelessoffice/ui/screens/DiagnosticsScreen.kt
+++ b/app/src/main/java/com/wirelessoffice/ui/screens/DiagnosticsScreen.kt
@@ -1,0 +1,71 @@
+package com.wirelessoffice.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.wirelessoffice.ui.viewmodel.DiagnosticsViewModel
+import com.wirelessoffice.ui.viewmodel.DiagnosticsViewModelFactory
+import com.wirelessoffice.util.DateFormat
+
+@Composable
+fun DiagnosticsScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
+    val viewModel: DiagnosticsViewModel = viewModel(factory = DiagnosticsViewModelFactory())
+    val uiState by viewModel.uiState.collectAsState()
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(text = "Diagnostics", style = MaterialTheme.typography.headlineSmall)
+        Text(
+            text = "Track BLE state, RSSI history, and logs here. Export uses the cache provider when implemented.",
+            style = MaterialTheme.typography.bodyMedium
+        )
+        Card {
+            Column(
+                modifier = Modifier.padding(PaddingValues(16.dp)),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(text = "BLE status", style = MaterialTheme.typography.titleMedium)
+                Text(text = "Scanning: Active (mock)")
+                Text(text = "Last error: None")
+                Text(text = "Devices seen: 3")
+            }
+        }
+        Text(text = "Recent events", style = MaterialTheme.typography.titleMedium)
+        LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            items(uiState.entries) { entry ->
+                Card {
+                    Column(modifier = Modifier.padding(12.dp)) {
+                        Text(text = DateFormat.format(entry.timestamp))
+                        Text(text = entry.message)
+                    }
+                }
+            }
+        }
+        Button(onClick = { viewModel.addEntry("Manual diagnostics ping") }) {
+            Text(text = "Add test entry")
+        }
+        Button(onClick = viewModel::clear) {
+            Text(text = "Clear logs")
+        }
+        Button(onClick = onBack) {
+            Text(text = "Back")
+        }
+    }
+}

--- a/app/src/main/java/com/wirelessoffice/ui/screens/OnboardingScreen.kt
+++ b/app/src/main/java/com/wirelessoffice/ui/screens/OnboardingScreen.kt
@@ -1,0 +1,65 @@
+package com.wirelessoffice.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.wirelessoffice.ui.viewmodel.OnboardingViewModel
+import com.wirelessoffice.ui.viewmodel.OnboardingViewModelFactory
+
+@Composable
+fun OnboardingScreen(onContinue: () -> Unit, modifier: Modifier = Modifier) {
+    val viewModel: OnboardingViewModel = viewModel(factory = OnboardingViewModelFactory())
+    val uiState by viewModel.uiState.collectAsState()
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.SpaceBetween,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            Text(
+                text = "Welcome to Wireless Office",
+                style = MaterialTheme.typography.headlineMedium
+            )
+            Text(
+                text = "Set up Bluetooth permissions, confirm device readiness, and start scanning for nearby devices.",
+                style = MaterialTheme.typography.bodyLarge
+            )
+            Card {
+                Column(
+                    modifier = Modifier.padding(PaddingValues(16.dp)),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text(text = "Setup checklist", style = MaterialTheme.typography.titleMedium)
+                    Text(text = "• Bluetooth enabled: ${statusLabel(uiState.permissions.bluetooth)}")
+                    Text(text = "• Location permission: ${statusLabel(uiState.permissions.location)}")
+                    Text(text = "• Camera permission: ${statusLabel(uiState.permissions.camera)}")
+                }
+            }
+        }
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Button(onClick = viewModel::refreshPermissions) {
+                Text(text = if (uiState.isRefreshing) "Refreshing..." else "Refresh permissions")
+            }
+            Button(onClick = onContinue) {
+                Text(text = "Start device scan")
+            }
+        }
+    }
+}
+
+private fun statusLabel(granted: Boolean): String = if (granted) "Ready" else "Needs access"

--- a/app/src/main/java/com/wirelessoffice/ui/state/DeviceListUiState.kt
+++ b/app/src/main/java/com/wirelessoffice/ui/state/DeviceListUiState.kt
@@ -1,0 +1,8 @@
+package com.wirelessoffice.ui.state
+
+import com.wirelessoffice.model.BleDevice
+
+data class DeviceListUiState(
+    val isScanning: Boolean,
+    val devices: List<BleDevice>
+)

--- a/app/src/main/java/com/wirelessoffice/ui/state/DiagnosticsUiState.kt
+++ b/app/src/main/java/com/wirelessoffice/ui/state/DiagnosticsUiState.kt
@@ -1,0 +1,7 @@
+package com.wirelessoffice.ui.state
+
+import com.wirelessoffice.model.DiagnosticsEntry
+
+data class DiagnosticsUiState(
+    val entries: List<DiagnosticsEntry>
+)

--- a/app/src/main/java/com/wirelessoffice/ui/state/OnboardingUiState.kt
+++ b/app/src/main/java/com/wirelessoffice/ui/state/OnboardingUiState.kt
@@ -1,0 +1,8 @@
+package com.wirelessoffice.ui.state
+
+import com.wirelessoffice.model.PermissionState
+
+data class OnboardingUiState(
+    val permissions: PermissionState,
+    val isRefreshing: Boolean
+)

--- a/app/src/main/java/com/wirelessoffice/ui/theme/Color.kt
+++ b/app/src/main/java/com/wirelessoffice/ui/theme/Color.kt
@@ -1,0 +1,10 @@
+package com.wirelessoffice.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val BluePrimary = Color(0xFF1B5EAB)
+val BlueSecondary = Color(0xFF4F83CC)
+val TealAccent = Color(0xFF27C3A3)
+val GrayBackground = Color(0xFFF4F6F9)
+val DarkBackground = Color(0xFF101418)
+val SurfaceLight = Color(0xFFFFFFFF)

--- a/app/src/main/java/com/wirelessoffice/ui/theme/Theme.kt
+++ b/app/src/main/java/com/wirelessoffice/ui/theme/Theme.kt
@@ -1,0 +1,47 @@
+package com.wirelessoffice.ui.theme
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+private val LightColors = lightColorScheme(
+    primary = BluePrimary,
+    secondary = BlueSecondary,
+    tertiary = TealAccent,
+    background = GrayBackground,
+    surface = SurfaceLight,
+    onPrimary = Color.White,
+    onSecondary = Color.White,
+    onTertiary = Color.White,
+    onBackground = Color(0xFF1A1C1E),
+    onSurface = Color(0xFF1A1C1E)
+)
+
+private val DarkColors = darkColorScheme(
+    primary = BlueSecondary,
+    secondary = BluePrimary,
+    tertiary = TealAccent,
+    background = DarkBackground,
+    surface = Color(0xFF1A1C1E),
+    onPrimary = Color.White,
+    onSecondary = Color.White,
+    onTertiary = Color.White,
+    onBackground = Color(0xFFE3E3E3),
+    onSurface = Color(0xFFE3E3E3)
+)
+
+@Composable
+fun WirelessOfficeTheme(
+    darkTheme: Boolean = false,
+    content: @Composable () -> Unit
+) {
+    val colors: ColorScheme = if (darkTheme) DarkColors else LightColors
+    MaterialTheme(
+        colorScheme = colors,
+        typography = Typography,
+        content = content
+    )
+}

--- a/app/src/main/java/com/wirelessoffice/ui/theme/Type.kt
+++ b/app/src/main/java/com/wirelessoffice/ui/theme/Type.kt
@@ -1,0 +1,40 @@
+package com.wirelessoffice.ui.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+val Typography = Typography(
+    headlineMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 28.sp,
+        lineHeight = 34.sp
+    ),
+    headlineSmall = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 24.sp,
+        lineHeight = 30.sp
+    ),
+    titleMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Medium,
+        fontSize = 18.sp,
+        lineHeight = 24.sp
+    ),
+    bodyLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        lineHeight = 22.sp
+    ),
+    bodyMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        lineHeight = 20.sp
+    )
+)

--- a/app/src/main/java/com/wirelessoffice/ui/viewmodel/DeviceListViewModel.kt
+++ b/app/src/main/java/com/wirelessoffice/ui/viewmodel/DeviceListViewModel.kt
@@ -1,0 +1,42 @@
+package com.wirelessoffice.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wirelessoffice.data.ScannerRepository
+import com.wirelessoffice.ui.state.DeviceListUiState
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+class DeviceListViewModel(private val scannerRepository: ScannerRepository) : ViewModel() {
+    val uiState: StateFlow<DeviceListUiState> = combine(
+        scannerRepository.devices,
+        scannerRepository.isScanning
+    ) { devices, scanning ->
+        DeviceListUiState(
+            isScanning = scanning,
+            devices = devices
+        )
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5_000),
+        DeviceListUiState(
+            isScanning = scannerRepository.isScanning.value,
+            devices = scannerRepository.devices.value
+        )
+    )
+
+    fun startScan() {
+        viewModelScope.launch {
+            scannerRepository.startScan()
+        }
+    }
+
+    fun stopScan() {
+        viewModelScope.launch {
+            scannerRepository.stopScan()
+        }
+    }
+}

--- a/app/src/main/java/com/wirelessoffice/ui/viewmodel/DiagnosticsViewModel.kt
+++ b/app/src/main/java/com/wirelessoffice/ui/viewmodel/DiagnosticsViewModel.kt
@@ -1,0 +1,33 @@
+package com.wirelessoffice.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wirelessoffice.data.DiagnosticsRepository
+import com.wirelessoffice.ui.state.DiagnosticsUiState
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+class DiagnosticsViewModel(private val diagnosticsRepository: DiagnosticsRepository) : ViewModel() {
+    val uiState: StateFlow<DiagnosticsUiState> = diagnosticsRepository.entries
+        .map { DiagnosticsUiState(entries = it) }
+        .stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5_000),
+            DiagnosticsUiState(entries = diagnosticsRepository.entries.value)
+        )
+
+    fun addEntry(message: String) {
+        viewModelScope.launch {
+            diagnosticsRepository.log(message)
+        }
+    }
+
+    fun clear() {
+        viewModelScope.launch {
+            diagnosticsRepository.clear()
+        }
+    }
+}

--- a/app/src/main/java/com/wirelessoffice/ui/viewmodel/OnboardingViewModel.kt
+++ b/app/src/main/java/com/wirelessoffice/ui/viewmodel/OnboardingViewModel.kt
@@ -1,0 +1,38 @@
+package com.wirelessoffice.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wirelessoffice.data.PermissionsRepository
+import com.wirelessoffice.ui.state.OnboardingUiState
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+class OnboardingViewModel(private val permissionsRepository: PermissionsRepository) : ViewModel() {
+    private val isRefreshing = MutableStateFlow(false)
+
+    val uiState: StateFlow<OnboardingUiState> = combine(
+        permissionsRepository.permissions,
+        isRefreshing
+    ) { permissions, refreshing ->
+        OnboardingUiState(permissions = permissions, isRefreshing = refreshing)
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5_000),
+        OnboardingUiState(
+            permissions = permissionsRepository.permissions.value,
+            isRefreshing = false
+        )
+    )
+
+    fun refreshPermissions() {
+        viewModelScope.launch {
+            isRefreshing.value = true
+            permissionsRepository.refresh()
+            isRefreshing.value = false
+        }
+    }
+}

--- a/app/src/main/java/com/wirelessoffice/ui/viewmodel/ViewModelFactory.kt
+++ b/app/src/main/java/com/wirelessoffice/ui/viewmodel/ViewModelFactory.kt
@@ -1,0 +1,35 @@
+package com.wirelessoffice.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.wirelessoffice.core.ServiceLocator
+
+class OnboardingViewModelFactory : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(OnboardingViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return OnboardingViewModel(ServiceLocator.permissionsRepository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}
+
+class DeviceListViewModelFactory : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(DeviceListViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return DeviceListViewModel(ServiceLocator.scannerRepository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}
+
+class DiagnosticsViewModelFactory : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(DiagnosticsViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return DiagnosticsViewModel(ServiceLocator.diagnosticsRepository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/java/com/wirelessoffice/util/DateFormat.kt
+++ b/app/src/main/java/com/wirelessoffice/util/DateFormat.kt
@@ -1,0 +1,12 @@
+package com.wirelessoffice.util
+
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+object DateFormat {
+    private val formatter = DateTimeFormatter.ofPattern("MMM d, HH:mm:ss")
+        .withZone(ZoneId.systemDefault())
+
+    fun format(instant: Instant): String = formatter.format(instant)
+}

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="@color/ic_launcher_foreground"
+        android:pathData="M28,36h52v8H28zM28,52h52v8H28zM28,68h36v8H28z" />
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,4 @@
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,4 @@
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,5 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.WirelessOffice" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor" tools:targetApi="l">@android:color/transparent</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<resources>
+    <color name="ic_launcher_background">#1B5EAB</color>
+    <color name="ic_launcher_foreground">#FFFFFF</color>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Wireless Office</string>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,5 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.WirelessOffice" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor" tools:targetApi="l">@android:color/transparent</item>
+    </style>
+</resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.2.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WirelessOffice Web</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1726 @@
+{
+  "name": "wirelessoffice-web",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wirelessoffice-web",
+      "version": "1.0.0",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
+        "@vitejs/plugin-react": "^4.3.1",
+        "typescript": "^5.5.4",
+        "vite": "^5.4.2"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.9.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
+      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001769",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
+      "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.286",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
+      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "wirelessoffice-web",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.1",
+    "typescript": "^5.5.4",
+    "vite": "^5.4.2"
+  }
+}

--- a/reports/dillon-tower-apk-deconstruction.md
+++ b/reports/dillon-tower-apk-deconstruction.md
@@ -1,0 +1,368 @@
+# APK Deconstruction Report — *Dillon Tower* (`Dillon Tower_1.1.111_APKPure.apk`)
+
+## 1) Identification & Build Targets
+
+**Package (applicationId):** `com.dillon.tower`  
+**Version:** `1.1.111` (**versionCode:** `111`)  
+**SDK:** **minSdk:** `25` (Android 7.1) · **targetSdk:** `33` (Android 13)  
+**compileSdkVersion:** `33`
+
+**Observed app label:** `Dillon Tower`
+
+---
+
+## 2) Technology Stack & App Type (Evidence-Based)
+
+This APK is **not** a conventional Kotlin/Java app. Multiple indicators show it is a **Xamarin.Android / Xamarin.Forms** app:
+
+### Xamarin / Mono runtime artifacts (present in APK)
+
+- `assemblies/assemblies.blob`
+- `assemblies/assemblies.manifest`
+- Native runtime libs:
+  - `lib/*/libmonodroid.so`
+  - `lib/*/libmonosgen-2.0.so`
+  - `lib/*/libmono-native.so`
+  - `lib/*/libmono-btls-shared.so`
+  - `lib/*/libxamarin-app.so`
+- Android component class names in manifest use Xamarin “crc…” naming (Java stubs generated for managed types), e.g.:
+  - `crc6403a3f33dab2f8200.MainActivity`
+
+**Implication for replication:** most business logic lives in **managed (.NET) assemblies**, not in `classes.dex`.
+
+---
+
+## 3) AndroidManifest.xml — Structure & Components
+
+### 3.1 Application-level configuration (observed)
+
+- `android:allowBackup="true"`
+- `android:extractNativeLibs="true"`
+- No explicit `usesCleartextTraffic` in manifest (not set here)
+- No explicit `networkSecurityConfig` in manifest (not set here)
+
+### 3.2 Declared Activities (2)
+
+1. **`crc6403a3f33dab2f8200.MainActivity`**
+   - `android:exported="true"`
+   - Launcher entry:
+     - `android.intent.action.MAIN`
+     - `android.intent.category.LAUNCHER`
+
+2. **`crc64a0e0a82d0db9a07d.IntermediateActivity`**
+   - No intent-filters declared
+   - (Likely an internal trampoline/splash/permission activity, but **function is not stated in manifest**.)
+
+### 3.3 Declared Receivers (2)
+
+- `crc64a0e0a82d0db9a07d.ConnectivityBroadcastReceiver` (`exported="false"`)
+- `crc643f46942d9dd1fff9.PowerSaveModeBroadcastReceiver` (`exported="false"`)
+
+### 3.4 Declared Content Providers (3)
+
+1. `crc647c3ddcd418b664a1.ClipboardContentProvider` (`exported="true"`)
+2. `xamarin.essentials.fileProvider` (`exported="false"`)
+3. `mono.MonoRuntimeProvider` (`exported="false"`)
+
+**Xamarin.Essentials FileProvider paths (decoded from `res/xml/xamarin_essentials_fileprovider_file_paths.xml`):**
+
+```xml
+<paths>
+  <external-path name="external_files" path="."/>
+  <cache-path name="internal_cache" path="."/>
+  <external-cache-path name="external_cache" path="."/>
+</paths>
+```
+
+### 3.5 `<queries>` (Package Visibility)
+
+Two intent queries are declared:
+
+- `android.media.action.IMAGE_CAPTURE`
+- `android.media.browse.MediaBrowserService`
+
+---
+
+## 4) Permissions & Hardware Features (Observed)
+
+### 4.1 Permissions (10)
+
+- `android.permission.INTERNET`
+- `android.permission.ACCESS_NETWORK_STATE`
+
+**Storage**
+
+- `android.permission.WRITE_EXTERNAL_STORAGE`
+
+**Location**
+
+- `android.permission.ACCESS_COARSE_LOCATION`
+- `android.permission.ACCESS_FINE_LOCATION`
+
+**Bluetooth**
+
+- `android.permission.BLUETOOTH` *(maxSdkVersion=30)*
+- `android.permission.BLUETOOTH_ADMIN` *(maxSdkVersion=30)*
+- `android.permission.BLUETOOTH_SCAN`
+- `android.permission.BLUETOOTH_CONNECT`
+
+**Camera**
+
+- `android.permission.CAMERA`
+
+### 4.2 Features
+
+- `android.hardware.location` (required=false)
+- `android.hardware.location.gps` (required=false)
+- `android.hardware.location.network` (required=false)
+- `android.hardware.bluetooth_le` (required=true)
+
+---
+
+## 5) Bundled Managed Assemblies (.NET) — High-Signal Inventory
+
+From `assemblies/assemblies.manifest`, notable assemblies include:
+
+### App / Domain assemblies
+
+- `Walkman`
+- `Walkman.Android`
+- `Walkman.Models`
+- `Skyline.Forms`
+- `AWTCommunication`
+
+### UX / UI & rendering
+
+- `Xamarin.Forms.Core`
+- `Xamarin.Forms.Xaml`
+- `Xamarin.Forms.Platform`
+- `Xamarin.Forms.Platform.Android`
+- `Xamarin.Forms.PancakeView`
+- `FFImageLoading` (+ Forms / Platform)
+- `Forms9Patch` (+ Droid)
+- `FormsGestures` (+ Droid)
+- `SkiaSharp`
+- `SkiaSharp.Views.Android`
+- `SkiaSharp.Views.Forms`
+- `SkiaSharp.Extended.Svg`
+
+### Device / capability libraries
+
+- `Xamarin.Essentials`
+- `Plugin.BLE` + `Plugin.BLE.Abstractions`
+- `System.IO.Ports`
+
+### Analytics / crash reporting
+
+- `Microsoft.AppCenter`
+- `Microsoft.AppCenter.Analytics`
+- `Microsoft.AppCenter.Crashes`
+- Android bindings for AppCenter analytics/crashes
+
+### Serialization / utils
+
+- `Newtonsoft.Json`
+- `MimeSharp`
+- `Jeffijoe.MessageFormat`
+- `P42.Utils` (+ Droid)
+- `P42.NumericalMethods`
+
+---
+
+## 6) Native Libraries (Observed)
+
+- `lib/*/libSkiaSharp.so` (multi-ABI)
+- Mono / Xamarin runtime libs (multi-ABI) listed earlier
+
+**Significance:** rendering (Skia) is a first-class capability; app UI may include custom drawing/SVG.
+
+---
+
+## 7) Network Endpoints / URLs Found (Low Count)
+
+From string extraction of `classes.dex`, the only clear HTTPS endpoints observed are:
+
+- `https://in.appcenter.ms`
+- `https://mobile.events.data.microsoft.com/OneCollector/1.0`
+- `https://www.example.com` *(placeholder/test string)*
+
+No app-specific API base URL was found in `classes.dex` via simple string extraction. (This is consistent with Xamarin apps where endpoints often reside in managed assemblies, may be obfuscated, or constructed dynamically.)
+
+---
+
+## 8) Core Functional Elements (Strictly Evidence-Driven)
+
+Below are **capabilities strongly indicated** by manifest + bundled libraries. This list is intentionally conservative.
+
+1. **Bluetooth Low Energy capability**
+   - Evidence:
+     - `android.hardware.bluetooth_le` required=true
+     - BLE permissions: `BLUETOOTH_SCAN`, `BLUETOOTH_CONNECT`, plus legacy `BLUETOOTH*`
+     - `Plugin.BLE` assemblies present
+
+2. **Location capability**
+   - Evidence:
+     - Location permissions (`COARSE`, `FINE`)
+     - Location hardware features declared (not required, but declared)
+
+3. **Camera capture / photo intent interoperability**
+   - Evidence:
+     - `android.permission.CAMERA`
+     - `<queries>` includes `android.media.action.IMAGE_CAPTURE`
+
+4. **External storage write access**
+   - Evidence:
+     - `WRITE_EXTERNAL_STORAGE`
+     - Xamarin.Essentials FileProvider supports external paths and caches
+
+5. **Network connectivity + telemetry**
+   - Evidence:
+     - `INTERNET`, `ACCESS_NETWORK_STATE`
+     - AppCenter analytics/crashes assemblies present
+     - `ConnectivityBroadcastReceiver` present (receiver name suggests connectivity monitoring)
+
+6. **Custom rendering / graphics**
+   - Evidence:
+     - SkiaSharp native libs and assemblies
+     - `SkiaSharp.Extended.Svg` suggests SVG rendering capability exists
+
+---
+
+## 9) What Codex Should Replicate (Functional Specification Skeleton)
+
+Because the original app’s **business logic is inside .NET assemblies**, a faithful replication should be planned around **capabilities and flows**, not class-for-class Android code.
+
+### 9.1 Minimum functional modules implied by evidence
+
+- **BLE Module**
+  - Scan (runtime permission handling for Android 12+)
+  - Connect / reconnect
+  - Read/write characteristics (or GATT interactions)
+  - Device list + connection state
+
+- **Permissions & Capability Gatekeeping**
+  - Location permission UX (Android ≤11 used for BLE scanning historically; Android 12+ uses BLUETOOTH_SCAN)
+  - Bluetooth permissions (S+)
+  - Camera permission
+  - Storage access (note: `WRITE_EXTERNAL_STORAGE` is legacy; modern apps should use scoped storage)
+
+- **Network + Telemetry Module**
+  - Network state detection
+  - Crash + analytics integration (or an equivalent telemetry provider if making the clone unique)
+
+- **Media / Camera Interop**
+  - Ability to invoke camera capture intent and ingest result (based on `<queries>` + permission)
+
+- **File Sharing / Storage**
+  - Export/share files via FileProvider-compatible URIs (mirroring Essentials provider behavior)
+
+- **Rendering Layer**
+  - If the UI includes custom drawing, replicate with:
+    - Jetpack Compose Canvas / SVG (e.g., AndroidSVG) **or**
+    - Skia via a native Android approach (less common)
+  - The original includes SkiaSharp; replication can be native equivalents.
+
+---
+
+## 10) Recommendations to Create a Unique Version (While Preserving Core)
+
+These recommendations keep core capabilities intact but ensure the new build is clearly distinct in implementation and surface design.
+
+### 10.1 Make the app “unique” at the product level
+
+- **Branding & identity**
+  - New app name, icon set, typography, color system, and layout rhythm
+- **Information architecture**
+  - Different navigation model (e.g., bottom nav vs. hamburger vs. stepper workflow)
+- **Onboarding**
+  - Add an explicit “Device Setup Wizard” flow:
+    - permissions → BLE scan → connect → validation → first action
+- **Diagnostics screen**
+  - BLE debug view (RSSI, connection state, characteristic values, last error)
+  - Export logs (ties naturally into FileProvider/storage capability)
+
+### 10.2 Make the app “unique” at the codebase level (recommended for Codex)
+
+Given the source is Xamarin.Forms, the cleanest unique replication is a **fresh native Android implementation**:
+
+**Option A (recommended):** Kotlin + Jetpack Compose + MVVM
+
+- BLE: Android `BluetoothLeScanner`, `BluetoothGatt` (or a well-known BLE abstraction)
+- Permissions: `ActivityResultContracts`, runtime permission orchestration
+- Storage: scoped storage + FileProvider for sharing
+- Telemetry: replace AppCenter with an alternative (or keep parity but implement differently)
+- Networking: OkHttp/Retrofit if an API exists (unknown from this APK)
+
+**Option B:** Flutter / React Native
+
+- Still unique vs. Xamarin, but more dependencies and different runtime
+
+### 10.3 Preserve behavior but diverge design
+
+- Keep:
+  - BLE scanning/connection + device interaction
+  - camera capture integration
+  - location permission handling (where required)
+  - file export/share
+- Change:
+  - UI composition and navigation
+  - naming conventions and domain models
+  - telemetry provider and event taxonomy
+  - graphics stack (SkiaSharp → Compose Canvas/SVG tooling)
+
+### 10.4 Replication guardrails (to avoid accidental drift)
+
+- Build a **capability parity checklist** directly from manifest + libs:
+  - BLE scan/connect works on Android 12/13/14 with correct permissions
+  - Camera capture intent works
+  - File export/share works via FileProvider URIs
+  - Network state detection exists
+  - Telemetry captures crashes
+- Add instrumentation tests around these behaviors.
+
+---
+
+## 11) Concrete “Codex Handoff” Blueprint (What to Ask Codex To Build)
+
+You can hand Codex the following scaffolded spec:
+
+1. **App shell**
+   - Single-activity Compose app
+   - Navigation graph: `Onboarding → DeviceList → DeviceDetail → (Optional) Diagnostics/Logs`
+
+2. **Permissions orchestrator**
+   - Determines required set by Android version:
+     - Android 12+ : `BLUETOOTH_SCAN`, `BLUETOOTH_CONNECT` (+ location if needed)
+     - Pre-12 : `BLUETOOTH`, `BLUETOOTH_ADMIN`, location as required
+   - Camera permission request
+   - Storage strategy: scoped storage + share sheet
+
+3. **BLE feature**
+   - Scan screen (filter, refresh, show RSSI, show connectable)
+   - Connect screen (services discovery, characteristic list)
+   - Minimal read/write framework (even if the exact UUIDs are unknown initially)
+
+4. **Logging/export**
+   - Local log buffer
+   - “Export logs” generates a file in cache and shares via FileProvider
+
+5. **Telemetry**
+   - Capture:
+     - app start
+     - permission granted/denied
+     - scan started/stopped
+     - device connected/disconnected
+     - exceptions/crashes
+
+---
+
+## Appendix A — Raw Manifest Highlights (Key Items Only)
+
+- Launcher activity: `crc6403a3f33dab2f8200.MainActivity`
+- Uses BLE (feature required), location, camera, storage write, internet
+- Xamarin.Essentials FileProvider paths include external path and caches
+- AppCenter endpoints present in dex strings
+
+---
+
+If you want, I can also extract and enumerate **resources (layouts, drawables, strings)** and do a deeper sweep of the **managed assemblies** (identifying likely namespaces/types) to tighten the feature spec further—without guessing at behavior beyond what’s present in the package.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "WirelessOffice"
+include(":app")

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useMemo, useState } from 'react'
+import {
+  addLog,
+  clearLogs,
+  fetchDevices,
+  fetchLogs,
+  fetchPermissions,
+  refreshPermissions
+} from '../data/mockApi'
+import type { BleDevice, DiagnosticsEntry, PermissionState } from '../model/types'
+
+type Route = 'onboarding' | 'devices' | 'detail' | 'diagnostics'
+
+export default function App() {
+  const [route, setRoute] = useState<Route>('onboarding')
+  const [selectedDevice, setSelectedDevice] = useState<BleDevice | null>(null)
+
+  const [permissions, setPermissions] = useState<PermissionState>({ bluetooth: false, location: false, camera: false })
+  const [devices, setDevices] = useState<BleDevice[]>([])
+  const [logs, setLogs] = useState<DiagnosticsEntry[]>([])
+  const [scanning, setScanning] = useState(false)
+
+  useEffect(() => {
+    void fetchPermissions().then(setPermissions)
+    void fetchLogs().then(setLogs)
+  }, [])
+
+  const permissionChecklist = useMemo(
+    () => [
+      { label: 'Bluetooth enabled', ready: permissions.bluetooth },
+      { label: 'Location permission', ready: permissions.location },
+      { label: 'Camera permission', ready: permissions.camera }
+    ],
+    [permissions]
+  )
+
+  async function handleRefreshPermissions() {
+    const updated = await refreshPermissions()
+    setPermissions(updated)
+    setLogs(await addLog('Permissions refreshed'))
+  }
+
+  async function handleStartScan() {
+    setScanning(true)
+    setDevices(await fetchDevices())
+    setLogs(await addLog('BLE scan started'))
+  }
+
+  async function handleStopScan() {
+    setScanning(false)
+    setLogs(await addLog('BLE scan stopped'))
+  }
+
+  const page = (() => {
+    if (route === 'onboarding') {
+      return (
+        <section className="panel">
+          <h1>Wireless Office Setup</h1>
+          <p>Prepare permissions and continue to BLE device discovery.</p>
+          <ul>
+            {permissionChecklist.map((item) => (
+              <li key={item.label}>{item.label}: {item.ready ? 'Ready' : 'Needs access'}</li>
+            ))}
+          </ul>
+          <div className="row">
+            <button onClick={handleRefreshPermissions}>Refresh permissions</button>
+            <button onClick={() => setRoute('devices')}>Continue</button>
+          </div>
+        </section>
+      )
+    }
+
+    if (route === 'devices') {
+      return (
+        <section className="panel">
+          <h1>Nearby devices</h1>
+          <p>Status: <strong>{scanning ? 'Scanning' : 'Idle'}</strong></p>
+          <div className="row">
+            <button onClick={handleStartScan}>Start scan</button>
+            <button onClick={handleStopScan}>Stop scan</button>
+            <button onClick={() => setRoute('diagnostics')}>Diagnostics</button>
+          </div>
+          <div className="cards">
+            {devices.map((device) => (
+              <button
+                className="card"
+                key={device.id}
+                onClick={() => {
+                  setSelectedDevice(device)
+                  setRoute('detail')
+                }}
+              >
+                <h3>{device.name}</h3>
+                <p>Address: {device.address}</p>
+                <p>RSSI: {device.rssi} dBm</p>
+                <p>Status: {device.status}</p>
+              </button>
+            ))}
+          </div>
+        </section>
+      )
+    }
+
+    if (route === 'detail') {
+      return (
+        <section className="panel">
+          <h1>Device detail</h1>
+          {selectedDevice ? (
+            <>
+              <p>Name: {selectedDevice.name}</p>
+              <p>Address: {selectedDevice.address}</p>
+              <p>Connection: {selectedDevice.status}</p>
+              <p>RSSI: {selectedDevice.rssi} dBm</p>
+            </>
+          ) : <p>No device selected.</p>}
+          <button onClick={() => setRoute('devices')}>Back</button>
+        </section>
+      )
+    }
+
+    return (
+      <section className="panel">
+        <h1>Diagnostics</h1>
+        <div className="row">
+          <button onClick={async () => setLogs(await addLog('Manual diagnostics ping'))}>Add test entry</button>
+          <button onClick={async () => setLogs(await clearLogs())}>Clear logs</button>
+          <button onClick={() => setRoute('devices')}>Back</button>
+        </div>
+        <div className="cards">
+          {logs.map((log) => (
+            <article key={log.id} className="card">
+              <p>{new Date(log.timestamp).toLocaleString()}</p>
+              <strong>{log.message}</strong>
+            </article>
+          ))}
+        </div>
+      </section>
+    )
+  })()
+
+  return <main className="app">{page}</main>
+}

--- a/src/data/mockApi.ts
+++ b/src/data/mockApi.ts
@@ -1,0 +1,46 @@
+import type { BleDevice, DiagnosticsEntry, PermissionState } from '../model/types'
+
+const seedDevices: BleDevice[] = [
+  { id: crypto.randomUUID(), name: 'Dillon Tower A1', address: 'C8:2B:96:AA:01:11', rssi: -62, status: 'Available' },
+  { id: crypto.randomUUID(), name: 'Dillon Tower B3', address: 'C8:2B:96:AA:02:FF', rssi: -70, status: 'Connected' },
+  { id: crypto.randomUUID(), name: 'Dillon Tower C7', address: 'C8:2B:96:AA:03:8C', rssi: -81, status: 'Available' }
+]
+
+let permissions: PermissionState = { bluetooth: true, location: false, camera: true }
+let logs: DiagnosticsEntry[] = [
+  { id: crypto.randomUUID(), message: 'App launched', timestamp: new Date().toISOString() },
+  { id: crypto.randomUUID(), message: 'Scanner initialized', timestamp: new Date().toISOString() }
+]
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+export async function fetchDevices(): Promise<BleDevice[]> {
+  await wait(250)
+  return [...seedDevices].sort(() => Math.random() - 0.5)
+}
+
+export async function refreshPermissions(): Promise<PermissionState> {
+  await wait(250)
+  permissions = { ...permissions, location: true }
+  return permissions
+}
+
+export async function fetchPermissions(): Promise<PermissionState> {
+  await wait(150)
+  return permissions
+}
+
+export async function fetchLogs(): Promise<DiagnosticsEntry[]> {
+  await wait(100)
+  return logs
+}
+
+export async function addLog(message: string): Promise<DiagnosticsEntry[]> {
+  logs = [{ id: crypto.randomUUID(), message, timestamp: new Date().toISOString() }, ...logs]
+  return logs
+}
+
+export async function clearLogs(): Promise<DiagnosticsEntry[]> {
+  logs = []
+  return logs
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './components/App'
+import './styles/app.css'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -1,0 +1,21 @@
+export type ConnectionStatus = 'Available' | 'Connecting' | 'Connected'
+
+export type BleDevice = {
+  id: string
+  name: string
+  address: string
+  rssi: number
+  status: ConnectionStatus
+}
+
+export type PermissionState = {
+  bluetooth: boolean
+  location: boolean
+  camera: boolean
+}
+
+export type DiagnosticsEntry = {
+  id: string
+  message: string
+  timestamp: string
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,0 +1,52 @@
+:root {
+  font-family: Inter, system-ui, sans-serif;
+  color: #13202f;
+  background: #f4f6f9;
+}
+
+body {
+  margin: 0;
+}
+
+.app {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.panel {
+  width: min(980px, 95vw);
+  background: white;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+}
+
+.row {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin: 1rem 0;
+}
+
+button {
+  border: 0;
+  border-radius: 10px;
+  background: #1b5eab;
+  color: white;
+  padding: 0.6rem 0.9rem;
+  cursor: pointer;
+}
+
+.cards {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.card {
+  text-align: left;
+  background: #eef4fb;
+  color: #13202f;
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()]
+})


### PR DESCRIPTION
### Motivation
- Prepare the scaffold for an enterprise-quality app by introducing explicit state management, DI, and observable ViewModel state for BLE, permissions, and diagnostics flows.
- Make the codebase easier to extend and test by adding repository interfaces and pluggable implementations so platform integrations (real BLE, permissions, cache) can be swapped in later.

### Description
- Added repository and model abstractions and in-memory fakes under `app/src/main/java/com/wirelessoffice/{core,data,model}` and a simple `ServiceLocator` to provide them. 
- Implemented `ViewModel`s and `ViewModelProvider` factories to expose immutable UI state (`DeviceListViewModel`, `OnboardingViewModel`, `DiagnosticsViewModel`) and connected Compose screens to those view models (`OnboardingScreen`, `DeviceListScreen`, `DiagnosticsScreen`, `DeviceDetailScreen`).
- Wired navigation and app shell in `WirelessOfficeApp` and `MainActivity`, added a small `DateFormat` util, theming (colors/typography), launcher resources, and strings.
- Updated Gradle config to enable Java time desugaring and lifecycle viewmodel compose with dependency updates in `app/build.gradle.kts`, and documented architecture notes in `README.md`.

### Testing
- No automated tests were executed for this change (scaffold and wiring only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6980fad83bd4832282dae02376108a1a)